### PR TITLE
add getHistoryMessages Method

### DIFF
--- a/android/src/main/java/com/lomocoin/imlib/RongCloudIMLibModule.java
+++ b/android/src/main/java/com/lomocoin/imlib/RongCloudIMLibModule.java
@@ -30,6 +30,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import io.rong.imlib.IRongCallback;
+import io.rong.imlib.RongCommonDefine;
 import io.rong.imlib.RongIMClient;
 import io.rong.imlib.RongIMClient.ResultCallback;
 import io.rong.imlib.model.Conversation;
@@ -196,7 +197,7 @@ public class RongCloudIMLibModule extends ReactContextBaseJavaModule {
                     }
                 });
 
-                
+
                 return true;
             }
         });
@@ -277,6 +278,109 @@ public class RongCloudIMLibModule extends ReactContextBaseJavaModule {
             }
         });
     }
+
+    @ReactMethod
+    public void getHistoryMessages(int mType, String targetId, int oldestMessageId, int count, final Promise promise){
+        ConversationType type = formatConversationType(mType);
+        RongIMClient.getInstance().getHistoryMessages(type, targetId, oldestMessageId, count, new ResultCallback<List<Message>>() {
+            @Override
+            public void onSuccess(List<Message> messages) {
+                WritableArray data = Arguments.createArray();
+
+                if (messages != null && !messages.isEmpty()) {
+                    for (int i = 0; i < messages.size(); i++) {
+                        Message message = messages.get(i);
+                        WritableMap item = formatMessage(message);
+                        data.pushMap(item);
+                    }
+                }
+                promise.resolve(data);
+            }
+
+            @Override
+            public void onError(RongIMClient.ErrorCode errorCode) {
+                promise.reject(errorCode.getValue() + "", errorCode.getMessage());
+            }
+        });
+    }
+
+    @ReactMethod
+    public void getDesignatedTypeHistoryMessages(int mType, String targetId, String objectName, int oldestMessageId, int count, final Promise promise){
+        ConversationType type = formatConversationType(mType);
+        RongIMClient.getInstance().getHistoryMessages(type, targetId, objectName, oldestMessageId, count, new ResultCallback<List<Message>>() {
+            @Override
+            public void onSuccess(List<Message> messages) {
+                WritableArray data = Arguments.createArray();
+
+                if (messages != null && !messages.isEmpty()) {
+                    for (int i = 0; i < messages.size(); i++) {
+                        Message message = messages.get(i);
+                        WritableMap item = formatMessage(message);
+                        data.pushMap(item);
+                    }
+                }
+                promise.resolve(data);
+            }
+
+            @Override
+            public void onError(RongIMClient.ErrorCode errorCode) {
+                promise.reject(errorCode.getValue() + "", errorCode.getMessage());
+            }
+        });
+    }
+
+    @ReactMethod
+    public void getDesignatedDirectionypeHistoryMessages(int mType, String targetId, String objectName, int baseMessageId, int count, int direction, final Promise promise){
+        ConversationType type = formatConversationType(mType);
+
+        RongIMClient.getInstance().getHistoryMessages(type, targetId, objectName, baseMessageId, count, getMessageDirection(direction), new ResultCallback<List<Message>>() {
+            @Override
+            public void onSuccess(List<Message> messages) {
+                WritableArray data = Arguments.createArray();
+
+                if (messages != null && !messages.isEmpty()) {
+                    for (int i = 0; i < messages.size(); i++) {
+                        Message message = messages.get(i);
+                        WritableMap item = formatMessage(message);
+                        data.pushMap(item);
+                    }
+                }
+                promise.resolve(data);
+            }
+
+            @Override
+            public void onError(RongIMClient.ErrorCode errorCode) {
+                promise.reject(errorCode.getValue() + "", errorCode.getMessage());
+            }
+        });
+    }
+
+    @ReactMethod
+    public void getBaseOnSentTimeHistoryMessages(int mType, String targetId, long sentTime, int before, int after, final Promise promise){
+        ConversationType type = formatConversationType(mType);
+
+        RongIMClient.getInstance().getHistoryMessages(type, targetId, sentTime, before, after, new ResultCallback<List<Message>>() {
+            @Override
+            public void onSuccess(List<Message> messages) {
+                WritableArray data = Arguments.createArray();
+
+                if (messages != null && !messages.isEmpty()) {
+                    for (int i = 0; i < messages.size(); i++) {
+                        Message message = messages.get(i);
+                        WritableMap item = formatMessage(message);
+                        data.pushMap(item);
+                    }
+                }
+                promise.resolve(data);
+            }
+
+            @Override
+            public void onError(RongIMClient.ErrorCode errorCode) {
+                promise.reject(errorCode.getValue() + "", errorCode.getMessage());
+            }
+        });
+    }
+
 
     @ReactMethod
     public void searchConversations(String keyWord, final Promise promise) {
@@ -460,7 +564,7 @@ public class RongCloudIMLibModule extends ReactContextBaseJavaModule {
         });
     }
 
- 
+
     //开始播放
     @ReactMethod
     public void audioPlayStart(String filePath, Promise promise) {
@@ -843,5 +947,13 @@ public class RongCloudIMLibModule extends ReactContextBaseJavaModule {
             default:
                 return ConversationType.GROUP;
         }
+    }
+
+    private RongCommonDefine.GetMessageDirection getMessageDirection(int direction){
+        if(direction == RongCommonDefine.GetMessageDirection.BEHIND.ordinal()){
+            return  RongCommonDefine.GetMessageDirection.BEHIND;
+        }
+
+        return  RongCommonDefine.GetMessageDirection.FRONT;
     }
 }

--- a/index.js
+++ b/index.js
@@ -45,18 +45,18 @@ export default {
         return RongCloudIMLib.connectWithToken(token);
     },
     getTotalUnreadCount() {
-    	// 获取全部未读消息数量（此消息数量为SDK本地查询到的未读消息数（有可能包含已退出群组的消息数量））
+        // 获取全部未读消息数量（此消息数量为SDK本地查询到的未读消息数（有可能包含已退出群组的消息数量））
         return RongCloudIMLib.getTotalUnreadCount();
     },
     getTargetUnreadCount(conversationType, targetId) {
-    	// 获取某个会话类型的target 的未读消息数
+        // 获取某个会话类型的target 的未读消息数
         return RongCloudIMLib.getTargetUnreadCount(conversationType, targetId);
     },
     getConversationsUnreadCount(conversationTypes) {
-    	// 获取某些会话类型（conversationTypes为数组）的未读消息数（此消息数量为SDK本地查询到的未读消息数（有可能包含已退出群组的消息数量））
+        // 获取某些会话类型（conversationTypes为数组）的未读消息数（此消息数量为SDK本地查询到的未读消息数（有可能包含已退出群组的消息数量））
         return RongCloudIMLib.getConversationsUnreadCount(conversationTypes);
     },
-    clearUnreadMessage(conversationType, targetId){
+    clearUnreadMessage(conversationType, targetId) {
         return RongCloudIMLib.clearUnreadMessage(conversationType, targetId);
     },
     searchConversations(keyword) {
@@ -67,6 +67,20 @@ export default {
     },
     getLatestMessages(type, targetId, count) {
         return RongCloudIMLib.getLatestMessages(type, targetId, count);
+    },
+    getHistoryMessages(type, targetId, oldestMessageId, count) {
+        return RongCloudIMLib.getHistoryMessages(type, targetId, oldestMessageId, count);
+    },
+    getDesignatedTypeHistoryMessages(type, targetId, objectName, oldestMessageId, count) {
+        return RongCloudIMLib.getDesignatedTypeHistoryMessages(type, targetId, objectName, oldestMessageId, count);
+    },
+    //仅支持android
+    getDesignatedDirectionypeHistoryMessages(type, targetId, objectName, baseMessageId, count, direction) {
+        return RongCloudIMLib.getDesignatedDirectionypeHistoryMessages(type, targetId, objectName, baseMessageId, count, direction);
+    },
+    //仅支持android
+    getBaseOnSentTimeHistoryMessages(type, targetId, sentTime, before, after) {
+        return RongCloudIMLib.getBaseOnSentTimeHistoryMessages(type, targetId, sentTime, before, after);
     },
     sendTextMessage(conversationType, targetId, content, pushContent) {
         return RongCloudIMLib.sendTextMessage(conversationType, targetId, content, pushContent);
@@ -90,39 +104,39 @@ export default {
         return RongCloudIMLib.audioPlayStop();
     },
     setConversationNotificationStatus(conversationType, targetId, isBlocked) {
-    	//设置会话消息提醒 isBlocked（true 屏蔽  false 新消息提醒）  （return  0:（屏蔽） 1:（新消息提醒））
-    	return RongCloudIMLib.setConversationNotificationStatus(conversationType, targetId, isBlocked);
+        //设置会话消息提醒 isBlocked（true 屏蔽  false 新消息提醒）  （return  0:（屏蔽） 1:（新消息提醒））
+        return RongCloudIMLib.setConversationNotificationStatus(conversationType, targetId, isBlocked);
     },
     getConversationNotificationStatus(conversationType, targetId) {
-    	//获取会话消息提醒状态  （return  0:（屏蔽） 1:（新消息提醒））
-    	return RongCloudIMLib.getConversationNotificationStatus(conversationType, targetId);
+        //获取会话消息提醒状态  （return  0:（屏蔽） 1:（新消息提醒））
+        return RongCloudIMLib.getConversationNotificationStatus(conversationType, targetId);
     },
     screenGlobalNotification() {
-    	//屏蔽全局新消息提醒
-    	return RongCloudIMLib.screenGlobalNotification();
+        //屏蔽全局新消息提醒
+        return RongCloudIMLib.screenGlobalNotification();
     },
     removeScreenOfGlobalNotification() {
-    	//移除全局新消息屏蔽
-    	return RongCloudIMLib.removeScreenOfGlobalNotification();
+        //移除全局新消息屏蔽
+        return RongCloudIMLib.removeScreenOfGlobalNotification();
     },
     getGlobalNotificationStatus() {
-    	//获取全局新消息提醒状态 （ return  0:（屏蔽） 1:（新消息提醒））
-    	return RongCloudIMLib.getGlobalNotificationStatus();
+        //获取全局新消息提醒状态 （ return  0:（屏蔽） 1:（新消息提醒））
+        return RongCloudIMLib.getGlobalNotificationStatus();
     },
     //isReceivePush-true 开启后台推送 false-关闭后台推送
     disconnect(isReceivePush) {
         return RongCloudIMLib.disconnect(isReceivePush);
     },
-    logout(){
+    logout() {
         return RongCloudIMLib.logout();
     },
     getFCMToken() {
-        if(Platform.OS === 'android'){
+        if (Platform.OS === 'android') {
             return RongCloudIMLib.getFCMToken();
-        }else{
+        } else {
             return '';
         }
     },
 
-    
+
 };


### PR DESCRIPTION
# 新增getHistoryMessages方法：
- android：[查考文档:](http://www.rongcloud.cn/docs/android_imlib.html#message_get_history_message)
getHistoryMessages (type, targetId, oldestMessageId, count)
getDesignatedTypeHistoryMessages(type, targetId, objectName, oldestMessageId, count)
getDesignatedDirectionypeHistoryMessages(type, targetId, objectName, baseMessageId, count, direction)
getBaseOnSentTimeHistoryMessages(type, targetId, sentTime, before, after)
- ios  [参考文档：](http://www.rongcloud.cn/docs/ios_imlib.html#message_get_latest_message)
getHistoryMessages (type, targetId, oldestMessageId, count)
getDesignatedTypeHistoryMessages(type, targetId, objectName, oldestMessageId, count)

增加的方法对应的融云lib中的api接口。